### PR TITLE
Added test for loading config file

### DIFF
--- a/__tests__/LLMtests.js
+++ b/__tests__/LLMtests.js
@@ -1,5 +1,42 @@
 const nock = require('nock');
-const { createREADME, getTokenUsage } = require('../ai');
+const fs = require('fs');
+const path = require('path');
+const { createREADME, getTokenUsage, loadConfig } = require('../ai');
+
+describe('Config File Tests', () => {
+  const tempFilePath = path.join(__dirname, 'temp-config.toml');
+
+  beforeEach(() => {
+    // Remove temp file before each test
+    if (fs.existsSync(tempFilePath)) {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
+  afterAll(() => {
+    // Remove temp file after tests are complete
+    if (fs.existsSync(tempFilePath)) {
+      fs.unlinkSync(tempFilePath);
+    }
+  });
+
+  it('Config File loads correctly', async () => {
+    fs.writeFileSync(tempFilePath, 'api = "test"');
+    const config = loadConfig(tempFilePath);
+    expect(config.api).toBe('test');
+  });
+
+  it('Config File does not exist', async () => {
+    const config = loadConfig('non-existent-file.toml');
+    expect(config).toEqual({});
+  });
+
+  it('Config File is empty', async () => {
+    fs.writeFileSync(tempFilePath, '');
+    const config = loadConfig();
+    expect(config).toEqual({});
+  });
+});
 
 describe('LLM README Generation Tests', () => {
   it('generates README content successfully', async () => {
@@ -7,7 +44,11 @@ describe('LLM README Generation Tests', () => {
     const fileNames = ['iLoveTesting.js'];
     const modelNumber = 0;
 
-    const readmeContent = await createREADME(fileContents, fileNames, modelNumber);
+    const readmeContent = await createREADME(
+      fileContents,
+      fileNames,
+      modelNumber
+    );
 
     expect(readmeContent);
   });
@@ -17,9 +58,11 @@ describe('LLM README Generation Tests', () => {
     const fileNames = ['iLoveTesting.js'];
     const modelNumber = null;
 
-    await expect(createREADME(fileContents, fileNames, modelNumber))
-      .rejects
-      .toThrow("400 {\"error\":{\"message\":\"'model' : property 'model' is missing\",\"type\":\"invalid_request_error\"}}");
+    await expect(
+      createREADME(fileContents, fileNames, modelNumber)
+    ).rejects.toThrow(
+      '400 {"error":{"message":"\'model\' : property \'model\' is missing","type":"invalid_request_error"}}'
+    );
   });
 
   it('gets the token usage from a response', async () => {
@@ -27,7 +70,11 @@ describe('LLM README Generation Tests', () => {
     const fileNames = ['iLoveTokens.js'];
     const modelNumber = 0;
 
-    const tokenUsage = await getTokenUsage(fileContents, fileNames, modelNumber);
+    const tokenUsage = await getTokenUsage(
+      fileContents,
+      fileNames,
+      modelNumber
+    );
 
     expect(tokenUsage);
   });

--- a/ai.js
+++ b/ai.js
@@ -2,20 +2,31 @@ require('dotenv').config({ path: './.env' });
 const Groq = require('groq-sdk');
 const fs = require('fs');
 const toml = require('toml');
-const {models} = require('./config');
+const { models } = require('./config');
 
-let configFile, config;
-if (fs.existsSync('./auto-README-config.toml')) {
-  //check of toml config file exist
-  try {
-    configFile = fs.readFileSync('./auto-README-config.toml', 'utf-8');
-    config = toml.parse(configFile);
-  } catch (err) {
-    console.error('Error in the toml file: ', err); //output an error if tiers error in the toml config file
+// Function to load the configuration file
+function loadConfig(fileName) {
+  let configFile, config;
+  let file = fileName || './auto-README-config.toml';
+  if (fs.existsSync(file)) {
+    //check if the toml config file exist
+    try {
+      configFile = fs.readFileSync(file, 'utf-8');
+      config = toml.parse(configFile);
+    } catch (err) {
+      console.error('Error in the toml file: ', err); //output an error if tiers error in the toml config file
+    }
   }
+  return config || {};
 }
 
-var api = config?.api || process.env.GROQ_API_KEY; //if toml config file has an api key, use the api in the toml file, if not use the one in the env file
+// Function to setup the API key
+function getApiKey() {
+  const config = loadConfig();
+  return config.api || process.env.GROQ_API_KEY; //if toml config file has an api key, use the api in the toml file, if not use the one in the env file
+}
+
+const api = getApiKey();
 
 const groq = new Groq({ apiKey: api });
 
@@ -63,4 +74,4 @@ async function getTokenUsage(fileContents, fileNames, modelNumber) {
   };
 }
 
-module.exports = { createREADME, getTokenUsage, models };
+module.exports = { createREADME, getTokenUsage, loadConfig, models };


### PR DESCRIPTION
# Code Changes & Testing Additions
In this PR I had to change some of the code to allow for testing. Previously there were 5 unaccounted for lines of testing in the ai.js file, making coverage around 78%. After my changes the coverage for ai.js is around 95% with only 1 unaccounted for line. When making changes for this PR, I ensured that functionality of the project was not interrupted at all, and used the original code in the function conversion to allow for very minimal changes overall.

## Code
I converted the loading of a config file default behaviour into a function, this allowed for the functionality of loading a config file to be included in testing. This function also allows for a config file to have a user passed in config file instead of the default behaviour in case you ever want to make an argument of a config file.

The function can be seen below:
> ![image](https://github.com/user-attachments/assets/8009c43f-b301-4d83-a2e9-8629935926f4)

## Test(s)
I added tests for loading a config file correctly, loading an empty config file, and loading a non-existent file. The 1 line of code not accounted for is ai.js line 17, which handles invalid input from a toml file.

The test(s) can be seen below (ignore my underlines, my vscode did not like your setup):
> ![image](https://github.com/user-attachments/assets/4de7df47-6ebd-41f5-b19f-39e24a3d71b6)

## Coverage
The final coverage of the tests can be seen below with my 3 added test cases:
> ![image](https://github.com/user-attachments/assets/45cfa496-516f-474c-b1dd-f74e30540e4a)